### PR TITLE
ci: enforce Pull Request title

### DIFF
--- a/.github/workflows/pr-metadata-checks.yml
+++ b/.github/workflows/pr-metadata-checks.yml
@@ -1,0 +1,16 @@
+name: Check Pull Request Metadata
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+jobs:
+  pr-enforce-conventional-commits:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check pull request title
+        uses: jef/conventional-commits-pr-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment: false # Post a comment in the pull request conversation with examples.


### PR DESCRIPTION
Add a dedicated GitHub workflow that checks that the Pull Request title follows conventional commits.

https://www.conventionalcommits.org/en/v1.0.0/#examples