### PR TITLE
docs: add how to do SVG screenshots for bpmn-visualization demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - [bpmn-rendering-from-version-to-version](bpmn-rendering-from-version-to-version/README.md): Generate screenshots of BPMN
   Diagram rendering of the migw-test-suite B.2.0 reference file with various bpmn-visualization versions.
 - [bpmn-rendering-miwg-test-suite](bpmn-rendering-miwg-test-suite/README.md): Generate screenshots of BPMN 
-Diagram rendering of all reference files from the miwg-test-suite project. It helps to publish the results for a given
+Diagram rendering of all reference files from the `miwg-test-suite` project. It helps to publish the results for a given
 bpmn-visualization version.
 
 ## Release process

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Internal tools for bpmn-visualization
 
-- [bpmn-visualization-svg-screenshots](bpmn-visualization-svg-screenshots): explain how to do SVG screenshots/exports of bpmn-visualization demo
 - [bpmn-rendering-from-version-to-version](bpmn-rendering-from-version-to-version/README.md): Generate screenshots of BPMN
   Diagram rendering of the migw-test-suite B.2.0 reference file with various bpmn-visualization versions.
 - [bpmn-rendering-miwg-test-suite](bpmn-rendering-miwg-test-suite/README.md): Generate screenshots of BPMN 
 Diagram rendering of all reference files from the `miwg-test-suite` project. It helps to publish the results for a given
 bpmn-visualization version.
+- [bpmn-visualization-svg-screenshots](bpmn-visualization-svg-screenshots): explain how to do SVG screenshots/exports of bpmn-visualization demo
 
 ## Release process
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Internal tools for bpmn-visualization
 
+- [bpmn-visualization-svg-screenshots](bpmn-visualization-svg-screenshots): explain how to do SVG screenshots/exports of bpmn-visualization demo
 - [bpmn-rendering-from-version-to-version](bpmn-rendering-from-version-to-version/README.md): Generate screenshots of BPMN
   Diagram rendering of the migw-test-suite B.2.0 reference file with various bpmn-visualization versions.
 - [bpmn-rendering-miwg-test-suite](bpmn-rendering-miwg-test-suite/README.md): Generate screenshots of BPMN 
 Diagram rendering of all reference files from the miwg-test-suite project. It helps to publish the results for a given
 bpmn-visualization version.
-
 
 ## Release process
 

--- a/bpmn-visualization-svg-screenshots/README.md
+++ b/bpmn-visualization-svg-screenshots/README.md
@@ -33,7 +33,6 @@ In the future, it may be possible to only export a dedicated html element. See h
 
 #### Final optimization of the SVG file
 
-Optimize the SVG content with svggo, for instance by using
+Optimize the SVG content with svggo, for instance by using https://jakearchibald.github.io/svgomg/.
+
 May be also available in html2svg in the future, see https://github.com/fathyb/html2svg/issues/5
-
-

--- a/bpmn-visualization-svg-screenshots/README.md
+++ b/bpmn-visualization-svg-screenshots/README.md
@@ -21,10 +21,19 @@ docker run fathyb/html2svg https://cdn.statically.io/gh/process-analytics/bpmn-v
 svg > monitoring.svg
 ```
 
-### post process
+### Post-process
 
-in the future, it may be possible ti only export a dedicated html element.
-See https://github.com/fathyb/html2svg/issues/27
+The visible part or the whole page have been exported as an SVG file. We need to crop the content to only keep the releavant part of the demo.
 
-todo find an esitor which is able to read the content of the exported svg.
-doesn't wirk with inkscape 1.2 on ubuntu 20.
+In the future, it may be possible to only export a dedicated html element. See https://github.com/fathyb/html2svg/issues/27
+
+**TODO** find an editor which is able to read the content of the exported svg.
+- On ubuntu 20, the svg files seem empty when opening them with inkscape 1.2 or the default Images Viewer.
+
+
+#### Final optimization of the SVG file
+
+Optimize the SVG content with svggo, for instance by using
+May be also available in html2svg in the future, see https://github.com/fathyb/html2svg/issues/5
+
+

--- a/bpmn-visualization-svg-screenshots/README.md
+++ b/bpmn-visualization-svg-screenshots/README.md
@@ -21,3 +21,10 @@ docker run fathyb/html2svg https://cdn.statically.io/gh/process-analytics/bpmn-v
 svg > monitoring.svg
 ```
 
+### post process
+
+in the future, it may be possible ti only export a dedicated html element.
+See https://github.com/fathyb/html2svg/issues/27
+
+todo find an esitor which is able to read the content of the exported svg.
+doesn't wirk with inkscape 1.2 on ubuntu 20.

--- a/bpmn-visualization-svg-screenshots/README.md
+++ b/bpmn-visualization-svg-screenshots/README.md
@@ -21,6 +21,11 @@ docker run fathyb/html2svg https://cdn.statically.io/gh/process-analytics/bpmn-v
 svg > monitoring.svg
 ```
 
+Don't forget to put the URL between quotes if it contains query parameters:
+```bash
+docker run fathyb/html2svg "https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/070cfc9/demo/monitoring-all-process-instances/index.html?useCase=frequency&dataType=both" --format svg > monitoring.svg
+```
+
 ### Post-process
 
 The visible part or the whole page have been exported as an SVG file. We need to crop the content to only keep the releavant part of the demo.

--- a/bpmn-visualization-svg-screenshots/README.md
+++ b/bpmn-visualization-svg-screenshots/README.md
@@ -2,9 +2,9 @@
 
 ## Context
 
-SVG instead of PNG (or other raster images): vectorial better rendering than regular images. For example, in the PA website. 
+Why using SVG instead of PNG (or other raster images)? Vectorial images offer better rendering than regular images. For example, for the PA website. 
 
-bpmn-visualization
+`bpmn-visualization`
   - SVG exporter: partially implemented, not fully working (overlays are misplaced). Only available in the code of the
   demo provided by the library (no API).
   - extract manually the SVG definition from the DOM: text are not correctly positioned. This is because we currently (v0.30.0)
@@ -32,8 +32,12 @@ The visible part or the whole page have been exported as an SVG file. We need to
 
 In the future, it may be possible to only export a dedicated html element. See https://github.com/fathyb/html2svg/issues/27
 
-**TODO** find an editor which is able to read the content of the exported svg.
+**TODO** find an editor which is able to read the content of the exported SVG.
 - On ubuntu 20, the svg files seem empty when opening them with inkscape 1.2 or the default Images Viewer.
+
+Workaround
+- update the content of the page to only keep the part you want to export as an SVG image. This is what was done in [PA website #899](https://github.com/process-analytics/process-analytics.dev/pull/899).
+
 
 
 #### Final optimization of the SVG file

--- a/bpmn-visualization-svg-screenshots/README.md
+++ b/bpmn-visualization-svg-screenshots/README.md
@@ -17,13 +17,18 @@ Why using SVG instead of PNG (or other raster images)? Vectorial images offer be
 https://github.com/fathyb/html2svg
 
 ```bash
-docker run fathyb/html2svg https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/v0.30.0/demo/monitoring-all-process-instances/index.html --format
-svg > monitoring.svg
+docker run fathyb/html2svg \
+  https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/v0.30.0/demo/monitoring-all-process-instances/index.html \
+  --format svg \
+  > monitoring.svg
 ```
 
 Don't forget to put the URL between quotes if it contains query parameters:
 ```bash
-docker run fathyb/html2svg "https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/070cfc9/demo/monitoring-all-process-instances/index.html?useCase=frequency&dataType=both" --format svg > monitoring.svg
+docker run fathyb/html2svg \
+  "https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/070cfc9/demo/monitoring-all-process-instances/index.html?useCase=frequency&dataType=both" \
+  --format svg \
+  > monitoring.svg
 ```
 
 ### Post-process

--- a/bpmn-visualization-svg-screenshots/README.md
+++ b/bpmn-visualization-svg-screenshots/README.md
@@ -1,0 +1,23 @@
+# How-to do SVG screenshots/exports of bpmn-visualization demo
+
+## Context
+
+SVG instead of PNG (or other raster images): vectorial better rendering than regular images. For example, in the PA website. 
+
+bpmn-visualization
+  - SVG exporter: partially implemented, not fully working (overlays are misplaced). Only available in the code of the
+  demo provided by the library (no API).
+  - extract manually the SVG definition from the DOM: text are not correctly positioned. This is because we currently (v0.30.0)
+  HTML labels that are positioned with foreign objects. The position is only accurate within the webpage
+  - extra CSS class applied to the elements: they would require to manually copy the CSS rules within the SVG definitions
+
+
+## A possible solution: `html2svg`
+
+https://github.com/fathyb/html2svg
+
+```bash
+docker run fathyb/html2svg https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/v0.30.0/demo/monitoring-all-process-instances/index.html --format
+svg > monitoring.svg
+```
+


### PR DESCRIPTION
Provide a way to do it with `html2svg`.

Tested with https://github.com/process-analytics/bpmn-visualization-examples/pull/464 for integration in the PA website: https://github.com/process-analytics/process-analytics.dev/pull/899