### PR TITLE
feat(miwg): enable "BPMN in Color" support

### DIFF
--- a/bpmn-rendering-miwg-test-suite/README.md
+++ b/bpmn-rendering-miwg-test-suite/README.md
@@ -1,5 +1,22 @@
 # Generate screenshots of BPMN Diagram from migw-test-suite with `bpmn-visualization`
 
+## Purpose
+
+This tools helps in preparing the `bpmn-visualization` submission to https://github.com/bpmn-miwg/bpmn-miwg-test-suite/, to demonstrate
+how it renders the Reference diagrams.
+
+The screenshots shows the "BPMN in Color" support of `bpmn-visualization` that has been introduced in version 0.35.0.
+
+
+### Submission process
+
+Everything is explained in https://github.com/bpmn-miwg/bpmn-miwg-test-suite/#how-to-test-a-bpmn-tool-using-this-test-suite.
+
+Use this tools to prepare the required resources prior creating a Pull Request.
+
+Think about automating if we submit often.
+
+
 ## Install
 
 Node: 16

--- a/bpmn-rendering-miwg-test-suite/README.md
+++ b/bpmn-rendering-miwg-test-suite/README.md
@@ -6,6 +6,9 @@ Node: 16
 
 Run `npm install`
 
+Test the dev server
+- run `npm run dev`
+- open http://localhost:5173/?bpmnFileName=C.1.0. The `bpmnFileName` query parameter is used to load any BPMN diagram available in the `public` directory.
 
 ## How-to use
 

--- a/bpmn-rendering-miwg-test-suite/package-lock.json
+++ b/bpmn-rendering-miwg-test-suite/package-lock.json
@@ -7,7 +7,7 @@
       "name": "bpmn-rendering-miwg-test-suite",
       "license": "Apache-2.0",
       "dependencies": {
-        "bpmn-visualization": "0.25.2"
+        "bpmn-visualization": "0.35.0"
       },
       "devDependencies": {
         "playwright-chromium": "~1.25.0",
@@ -133,15 +133,13 @@
       "dev": true
     },
     "node_modules/bpmn-visualization": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-0.25.2.tgz",
-      "integrity": "sha512-SErm2/505WJC808RBslf3G+FIubxhNCznGsa/0ubB/W3kEEM6Ach60HBW8TiuepFpWUuxatrAt1bi1aDxtErcg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-0.35.0.tgz",
+      "integrity": "sha512-8cwfzy3Xb5bqjo+eI/Xqt8zryUF7y1UtK5rRX2nJ1dg3r3HU/vqOzplEIMkVXHrIGIobq+S4f5N9NwRXAbM58A==",
       "dependencies": {
         "@typed-mxgraph/typed-mxgraph": "~1.0.7",
-        "entities": "~4.3.1",
-        "fast-xml-parser": "4.0.9",
-        "lodash.debounce": "~4.0.8",
-        "lodash.throttle": "~4.1.1",
+        "fast-xml-parser": "4.2.2",
+        "lodash-es": "~4.17.21",
         "mxgraph": "4.2.2",
         "strnum": "1.0.5"
       }
@@ -159,17 +157,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/esbuild": {
@@ -529,18 +516,24 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.9.tgz",
-      "integrity": "sha512-4G8EzDg2Nb1Qurs3f7BpFV4+jpMVsdgLVuG1Uv8O2OHJfVCg7gcA53obuKbmVqzd4Y7YXVBK05oJG7hzGIdyzg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.2.tgz",
+      "integrity": "sha512-DLzIPtQqmvmdq3VUKR7T6omPK/VCRNqgFlGtbESfyhcH2R4I8EzK1/K6E8PkRCK2EabWrUHK32NjYRbEFnnz0Q==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fsevents": {
@@ -587,15 +580,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "node_modules/lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -950,15 +938,13 @@
       "dev": true
     },
     "bpmn-visualization": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-0.25.2.tgz",
-      "integrity": "sha512-SErm2/505WJC808RBslf3G+FIubxhNCznGsa/0ubB/W3kEEM6Ach60HBW8TiuepFpWUuxatrAt1bi1aDxtErcg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-0.35.0.tgz",
+      "integrity": "sha512-8cwfzy3Xb5bqjo+eI/Xqt8zryUF7y1UtK5rRX2nJ1dg3r3HU/vqOzplEIMkVXHrIGIobq+S4f5N9NwRXAbM58A==",
       "requires": {
         "@typed-mxgraph/typed-mxgraph": "~1.0.7",
-        "entities": "~4.3.1",
-        "fast-xml-parser": "4.0.9",
-        "lodash.debounce": "~4.0.8",
-        "lodash.throttle": "~4.1.1",
+        "fast-xml-parser": "4.2.2",
+        "lodash-es": "~4.17.21",
         "mxgraph": "4.2.2",
         "strnum": "1.0.5"
       }
@@ -974,11 +960,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
-    },
-    "entities": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg=="
     },
     "esbuild": {
       "version": "0.14.53",
@@ -1150,9 +1131,9 @@
       "optional": true
     },
     "fast-xml-parser": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.9.tgz",
-      "integrity": "sha512-4G8EzDg2Nb1Qurs3f7BpFV4+jpMVsdgLVuG1Uv8O2OHJfVCg7gcA53obuKbmVqzd4Y7YXVBK05oJG7hzGIdyzg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.2.tgz",
+      "integrity": "sha512-DLzIPtQqmvmdq3VUKR7T6omPK/VCRNqgFlGtbESfyhcH2R4I8EzK1/K6E8PkRCK2EabWrUHK32NjYRbEFnnz0Q==",
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -1188,15 +1169,10 @@
         "has": "^1.0.3"
       }
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "make-error": {
       "version": "1.3.6",

--- a/bpmn-rendering-miwg-test-suite/package.json
+++ b/bpmn-rendering-miwg-test-suite/package.json
@@ -12,7 +12,7 @@
     "generate-screenshots": "ts-node --esm scripts/generate-screenshots.ts"
   },
   "dependencies": {
-    "bpmn-visualization": "0.25.2"
+    "bpmn-visualization": "0.35.0"
   },
   "devDependencies": {
     "playwright-chromium": "~1.25.0",

--- a/bpmn-rendering-miwg-test-suite/src/main.ts
+++ b/bpmn-rendering-miwg-test-suite/src/main.ts
@@ -1,7 +1,7 @@
 import './style.css'
 import {BpmnVisualization, FitType} from "bpmn-visualization";
 
-const bpmnVisualization = new BpmnVisualization({container: 'bpmn-container'});
+const bpmnVisualization = new BpmnVisualization({container: 'bpmn-container', renderer: {ignoreBpmnColors: false}});
 
 const fetchBpmnContent = (url: string) => fetch(url)
     .then(response => {


### PR DESCRIPTION
Bump bpmn-visualization from 0.25.2 to 0.35.0 and improve the README.

Closes #19 


![image](https://github.com/process-analytics/bpmn-visualization-tools/assets/27200110/fbd145bc-c4e2-47c8-8eac-3f4e17e17cda)
_http://localhost:5173/?bpmnFileName=C.1.0_