### PR TITLE
feat(miwg): configure viewport and exported file name

### DIFF
--- a/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
+++ b/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
@@ -54,8 +54,8 @@ const configuration = new Map<string, Configuration>([
     // ['C.1.0', {}], // no need for config
     // ['C.2.0', {}], // no need for config
     // ['C.3.0', {}], // no need for config
-    ['C.4.0', {diagramsNumber: 4}],  // no need for viewport
-    ['C.5.0', {diagramsNumber: 2, viewport: {width: 3821, height: 984}}],  // viewport only for the first diagram (other viewports will be configured later when we support the rendering of more diagrams)
+    ['C.4.0', {diagramsNumber: 4, viewport: {width: 2240, height: 800}}], // viewport only for the first diagram (other viewports will be configured later when we support the rendering of more diagrams)
+    ['C.5.0', {diagramsNumber: 2, viewport: {width: 3821, height: 984}}], // viewport only for the first diagram (other viewports will be configured later when we support the rendering of more diagrams)
     ['C.6.0', {viewport: {width: 2081, height: 942}}],
     // ['C.7.0', {}], // no need for config
     ['C.8.0', {viewport: {width: 2158, height: 850}}],

--- a/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
+++ b/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
@@ -66,8 +66,6 @@ const baseUrl = 'localhost:5173/index.html';
 
 // playwright default
 const defaultViewPort = { width: 1280, height: 720 };
-// other
-// const defaultViewPort = { width: 1024, height: 768 };
 
 (async () => {
     const browser = await chromium.launch({headless: false});

--- a/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
+++ b/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
@@ -39,14 +39,21 @@ fs.mkdirSync(outputDirectory, {recursive: true});
 //     .filter(file => file.endsWith('.bpmn'))
 //     .map(file => file.substring(0, file.indexOf('.bpmn')));
 // TODO temp to configure the viewport for each file
-const diagrams = ['A.1.0', 'B.2.0', 'C.4.0'];
+const diagrams = ['A.3.0'];
+// const diagrams = ['A.1.0', 'B.2.0', 'C.4.0'];
 
 // configuration stores viewport
 // TODO we currently use an arbitrary load configuration for fit. See if we need to configure it for each file and diagram
 // TODO for files that contain several diagrams, need to list diagram index, dedicated viewport
 const configuration = new Map<string, Configuration>([
+    ['A.1.0', {viewport: {width: 771, height: 111}}],
+    ['A.2.0', {viewport: {width: 810, height: 343}}],
+    // ['A.2.1', {viewport: {width: 810, height: 343}}],
+    ['A.3.0', {viewport: {width: 770, height: 440}}],
     ['B.2.0', {viewport: {width: 2078, height: 1616}}],
+    // viewport only for the first diagram (other viewports will be configured later when we support the rendering of more diagrams)
     ['C.4.0', {diagramsNumber: 4}],
+    // viewport only for the first diagram (other viewports will be configured later when we support the rendering of more diagrams)
     ['C.5.0', {diagramsNumber: 2}],
 ]);
 

--- a/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
+++ b/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
@@ -69,12 +69,10 @@ const defaultViewPort = { width: 1280, height: 720 };
 
         await page.goto(`${baseUrl}?bpmnFileName=${fileName}`);
 
-        // TODO wait for generated element instead of waiting for 1 second (risk of flaky generation, see https://playwright.dev/docs/api/class-page#pagewaitfortimeouttimeout)
-        // we do this in tests (for specific elements, this require data attribute that are not available in all versions or the attribute name changes from version to version
-        // we could at least check mxgraph initialization (svg node in the bpmn-container, but it may not have the same id in all pages)
-        // or check the existence of bpmn svg nodes (probably the easiest way as they will be present for all versions)
         console.info('Waiting for diagram rendering...');
-        // TODO the 2nd group is not empty (should also be checked in the other tool)
+        // TODO wait for generated element instead of waiting for 1 second (risk of flaky generation, see https://playwright.dev/docs/api/class-page#pagewaitfortimeouttimeout)
+        // we do this in bpmn-visualization tests
+        // we could at least check mxgraph initialization or check the existence of a specific BPMN SVG nodes by looking for its related data-bpmn-id
         await page.waitForTimeout(1000);
         console.info('Wait done');
 

--- a/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
+++ b/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
@@ -45,7 +45,7 @@ const diagrams = ['A.1.0', 'B.2.0', 'C.4.0'];
 // TODO we currently use an arbitrary load configuration for fit. See if we need to configure it for each file and diagram
 // TODO for files that contain several diagrams, need to list diagram index, dedicated viewport
 const configuration = new Map<string, Configuration>([
-    ['B.2.0', {viewport: { width: 2078, height: 1616 }}],
+    ['B.2.0', {viewport: {width: 2078, height: 1616}}],
     ['C.4.0', {diagramsNumber: 4}],
     ['C.5.0', {diagramsNumber: 2}],
 ]);
@@ -81,7 +81,7 @@ const defaultViewPort = { width: 1280, height: 720 };
         // https://playwright.dev/docs/screenshots
         // TODO ensure no fullPage, configure css to make fitCenter work or configure viewport for each file
         // TODO when several bpmn diagram in a file, the file name must be prefix by '.<number>'
-        const screenshotFileNamePostfix = diagramConfiguration?.diagramsNumber ? '-1' : '';
+        const screenshotFileNamePostfix = diagramConfiguration?.diagramsNumber ? '.1' : '';
         await page.screenshot({path: `${outputDirectory}/${fileName}-import${screenshotFileNamePostfix}.png`, fullPage: true});
         console.info(`Screenshot generated for ${fileName}`);
         // TODO decide if we use need to use 'locator'

--- a/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
+++ b/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
@@ -39,7 +39,7 @@ fs.mkdirSync(outputDirectory, {recursive: true});
 //     .filter(file => file.endsWith('.bpmn'))
 //     .map(file => file.substring(0, file.indexOf('.bpmn')));
 // TODO temp to configure the viewport for each file
-const diagrams = ['A.3.0'];
+const diagrams = ['C.8.0'];
 // const diagrams = ['A.1.0', 'B.2.0', 'C.4.0'];
 
 // configuration stores viewport
@@ -50,11 +50,21 @@ const configuration = new Map<string, Configuration>([
     ['A.2.0', {viewport: {width: 810, height: 343}}],
     // ['A.2.1', {viewport: {width: 810, height: 343}}],
     ['A.3.0', {viewport: {width: 770, height: 440}}],
+    // ['A.4.0', {viewport: {width: 810, height: 343}}],
+    // ['A.4.1', {viewport: {width: 810, height: 343}}],
+    // ['B.1.0', {viewport: {width: 2078, height: 1616}}],
     ['B.2.0', {viewport: {width: 2078, height: 1616}}],
+    // ['C.1.0', {viewport: {width: 771, height: 111}}],
+    // ['C.2.0', {viewport: {width: 771, height: 111}}],
+    // ['C.3.0', {viewport: {width: 771, height: 111}}],
     // viewport only for the first diagram (other viewports will be configured later when we support the rendering of more diagrams)
     ['C.4.0', {diagramsNumber: 4}],
     // viewport only for the first diagram (other viewports will be configured later when we support the rendering of more diagrams)
     ['C.5.0', {diagramsNumber: 2}],
+    // ['C.6.0', {viewport: {width: 771, height: 111}}],
+    // ['C.7.0', {viewport: {width: 771, height: 111}}],
+    ['C.8.0', {viewport: {width: 2158, height: 850}}],
+    // ['C.8.1', {viewport: {width: 771, height: 111}}],
 ]);
 
 const baseUrl = 'localhost:5173/index.html';

--- a/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
+++ b/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
@@ -39,7 +39,7 @@ fs.mkdirSync(outputDirectory, {recursive: true});
 //     .filter(file => file.endsWith('.bpmn'))
 //     .map(file => file.substring(0, file.indexOf('.bpmn')));
 // TODO temp to configure the viewport for each file
-const diagrams = ['C.8.0'];
+const diagrams = ['A.4.1'];
 // const diagrams = ['A.1.0', 'B.2.0', 'C.4.0'];
 
 // configuration stores viewport
@@ -48,12 +48,11 @@ const diagrams = ['C.8.0'];
 const configuration = new Map<string, Configuration>([
     ['A.1.0', {viewport: {width: 771, height: 111}}],
     ['A.2.0', {viewport: {width: 810, height: 343}}],
-    // ['A.2.1', {viewport: {width: 810, height: 343}}],
     ['A.3.0', {viewport: {width: 770, height: 440}}],
-    // ['A.4.0', {viewport: {width: 810, height: 343}}],
-    // ['A.4.1', {viewport: {width: 810, height: 343}}],
+    ['A.4.0', {viewport: {width: 1222, height: 807}}],
+    ['A.4.1', {viewport: {width: 1284, height: 1037}}],
     // ['B.1.0', {viewport: {width: 2078, height: 1616}}],
-    ['B.2.0', {viewport: {width: 2078, height: 1616}}],
+    ['B.2.0', {viewport: {width: 2078, height: 1616}}],  // TODO keep ratio but reduce size? Review ref dimension
     // ['C.1.0', {viewport: {width: 771, height: 111}}],
     // ['C.2.0', {viewport: {width: 771, height: 111}}],
     // ['C.3.0', {viewport: {width: 771, height: 111}}],
@@ -61,9 +60,9 @@ const configuration = new Map<string, Configuration>([
     ['C.4.0', {diagramsNumber: 4}],
     // viewport only for the first diagram (other viewports will be configured later when we support the rendering of more diagrams)
     ['C.5.0', {diagramsNumber: 2}],
-    // ['C.6.0', {viewport: {width: 771, height: 111}}],
+    ['C.6.0', {viewport: {width: 2081, height: 942}}], // TODO keep ratio but reduce size?
     // ['C.7.0', {viewport: {width: 771, height: 111}}],
-    ['C.8.0', {viewport: {width: 2158, height: 850}}],
+    ['C.8.0', {viewport: {width: 2158, height: 850}}],  // TODO keep ratio but reduce size?
     // ['C.8.1', {viewport: {width: 771, height: 111}}],
 ]);
 
@@ -71,6 +70,8 @@ const baseUrl = 'localhost:5173/index.html';
 
 // playwright default
 const defaultViewPort = { width: 1280, height: 720 };
+// other
+// const defaultViewPort = { width: 1024, height: 768 };
 
 (async () => {
     const browser = await chromium.launch({headless: false});

--- a/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
+++ b/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
@@ -39,7 +39,7 @@ const diagrams = fs.readdirSync('public')
     .filter(file => file.endsWith('.bpmn'))
     .map(file => file.substring(0, file.indexOf('.bpmn')));
 // Use this to check a dedicated diagram
-// const diagrams = ['C.8.1'];
+// const diagrams = ['B.2.0'];
 // const diagrams = ['A.1.0', 'B.2.0', 'C.4.0'];
 
 // configuration stores viewport
@@ -50,7 +50,7 @@ const configuration = new Map<string, Configuration>([
     ['A.4.0', {viewport: {width: 1222, height: 807}}],
     ['A.4.1', {viewport: {width: 1284, height: 1037}}],
     ['B.1.0', {viewport: {width: 1103, height: 1011}}],
-    ['B.2.0', {viewport: {width: 1284, height: 942}}],
+    ['B.2.0', {viewport: {width: 1926, height: 1413}}],
     // ['C.1.0', {}], // no need for config
     // ['C.2.0', {}], // no need for config
     // ['C.3.0', {}], // no need for config

--- a/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
+++ b/bpmn-rendering-miwg-test-suite/scripts/generate-screenshots.ts
@@ -35,35 +35,31 @@ fs.mkdirSync(outputDirectory, {recursive: true});
 
 
 // list files from the public directory
-// const diagrams = fs.readdirSync('public')
-//     .filter(file => file.endsWith('.bpmn'))
-//     .map(file => file.substring(0, file.indexOf('.bpmn')));
-// TODO temp to configure the viewport for each file
-const diagrams = ['A.4.1'];
+const diagrams = fs.readdirSync('public')
+    .filter(file => file.endsWith('.bpmn'))
+    .map(file => file.substring(0, file.indexOf('.bpmn')));
+// Use this to check a dedicated diagram
+// const diagrams = ['C.8.1'];
 // const diagrams = ['A.1.0', 'B.2.0', 'C.4.0'];
 
 // configuration stores viewport
-// TODO we currently use an arbitrary load configuration for fit. See if we need to configure it for each file and diagram
-// TODO for files that contain several diagrams, need to list diagram index, dedicated viewport
 const configuration = new Map<string, Configuration>([
     ['A.1.0', {viewport: {width: 771, height: 111}}],
     ['A.2.0', {viewport: {width: 810, height: 343}}],
     ['A.3.0', {viewport: {width: 770, height: 440}}],
     ['A.4.0', {viewport: {width: 1222, height: 807}}],
     ['A.4.1', {viewport: {width: 1284, height: 1037}}],
-    // ['B.1.0', {viewport: {width: 2078, height: 1616}}],
-    ['B.2.0', {viewport: {width: 2078, height: 1616}}],  // TODO keep ratio but reduce size? Review ref dimension
-    // ['C.1.0', {viewport: {width: 771, height: 111}}],
-    // ['C.2.0', {viewport: {width: 771, height: 111}}],
-    // ['C.3.0', {viewport: {width: 771, height: 111}}],
-    // viewport only for the first diagram (other viewports will be configured later when we support the rendering of more diagrams)
-    ['C.4.0', {diagramsNumber: 4}],
-    // viewport only for the first diagram (other viewports will be configured later when we support the rendering of more diagrams)
-    ['C.5.0', {diagramsNumber: 2}],
-    ['C.6.0', {viewport: {width: 2081, height: 942}}], // TODO keep ratio but reduce size?
-    // ['C.7.0', {viewport: {width: 771, height: 111}}],
-    ['C.8.0', {viewport: {width: 2158, height: 850}}],  // TODO keep ratio but reduce size?
-    // ['C.8.1', {viewport: {width: 771, height: 111}}],
+    ['B.1.0', {viewport: {width: 1103, height: 1011}}],
+    ['B.2.0', {viewport: {width: 1284, height: 942}}],
+    // ['C.1.0', {}], // no need for config
+    // ['C.2.0', {}], // no need for config
+    // ['C.3.0', {}], // no need for config
+    ['C.4.0', {diagramsNumber: 4}],  // no need for viewport
+    ['C.5.0', {diagramsNumber: 2, viewport: {width: 3821, height: 984}}],  // viewport only for the first diagram (other viewports will be configured later when we support the rendering of more diagrams)
+    ['C.6.0', {viewport: {width: 2081, height: 942}}],
+    // ['C.7.0', {}], // no need for config
+    ['C.8.0', {viewport: {width: 2158, height: 850}}],
+    ['C.8.1', {viewport: {width: 1920, height: 800}}],
 ]);
 
 const baseUrl = 'localhost:5173/index.html';


### PR DESCRIPTION
This lets generated PNG image with a convenient display of most screens.
Also export files with the right names when there are several BPMN diagrams within the file.